### PR TITLE
feat: load the git profile path from an environment variable

### DIFF
--- a/app/Git/Profile/Run.hs
+++ b/app/Git/Profile/Run.hs
@@ -6,7 +6,7 @@ import qualified Data.Text                          as T
 import           Git.Profile.App.RunSwitch          (runSwitch)
 import           Git.Profile.App.SwitchEnv
 import           Git.Profile.Cli.CommandLineOptions
-import           Git.Profile.GitProfile             (defaultGitProfilePath)
+import           Git.Profile.GitProfile             (envOrDefaultGitProfilePath)
 import           RIO
 
 runApp :: CommandLineOptions -> IO ()
@@ -14,9 +14,7 @@ runApp (SwitchCmd (SwitchArguments profileName profileFilePathMaybe)) =
     flip runContT return $ do
         logOptions <- logOptionsHandle stderr False
         logFunc <- ContT $ withLogFunc logOptions
-        profileFilePath <- case profileFilePathMaybe of
-            Just a  -> pure a
-            Nothing -> T.pack <$> defaultGitProfilePath
+        profileFilePath <- maybe (T.pack <$> envOrDefaultGitProfilePath) pure profileFilePathMaybe
         let env = Env
                     { envProfileName = profileName
                     , envProfileFilePath = profileFilePath

--- a/src/Git/Profile/GitProfile.hs
+++ b/src/Git/Profile/GitProfile.hs
@@ -1,27 +1,42 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Git.Profile.GitProfile where
+module Git.Profile.GitProfile
+    ( GitProfile
+    , ProfileName
+    , GitConfigs
+    , ConfigCategory
+    , envOrDefaultGitProfilePath
+    , loadGitProfile
+    ) where
 
 import           Control.Monad.IO.Class
 import qualified Data.Map               as M
 import qualified Data.Text              as T
 import qualified Data.Yaml.Aeson        as Y
 import           RIO                    ()
+import           System.Environment     (lookupEnv)
 import           Turtle                 ((</>))
 import qualified Turtle
 
 type GitProfile = M.Map ProfileName GitConfigs
 type ProfileName = T.Text
 
-type GitConfigs = M.Map ConfigCategory (M.Map Key Value)
+type GitConfigs = M.Map ConfigCategory (M.Map T.Text T.Text)
 type ConfigCategory = T.Text
-type Key = T.Text
-type Value = T.Text
 
 -- |Gets a default path to '.gitprofile'.
 defaultGitProfilePath :: MonadIO m => m String
 defaultGitProfilePath = do
     h <- liftIO Turtle.home
     pure . Turtle.encodeString $ h </> ".gitprofile"
+
+-- |Gets a path to the git profile from environment variables.
+envGitProfilePath :: MonadIO m => m (Maybe String)
+envGitProfilePath = liftIO $ lookupEnv "GIT_PROFILE_PATH"
+
+-- |Gets a path to the git profile from environment variables if possible,
+--  gets a default path otherwise.
+envOrDefaultGitProfilePath :: MonadIO m => m String
+envOrDefaultGitProfilePath = envGitProfilePath >>= maybe defaultGitProfilePath pure
 
 -- |Loads the specific path as 'GitProfile'.
 loadGitProfile :: MonadIO m => String -> m GitProfile


### PR DESCRIPTION
Currently, the way to read `.gitprofile` is :

1. specifing a path in the command line argument
2. the default location which is `$HOME/.gitprofile`

This PR allows specifying a path in an environment variable `GIT_PROFILE_PATH`. They are prioritized like below :

1. the command line argument
2. the environment variable
3. the command line argument